### PR TITLE
Embed original traceback in Hydra's exception report.

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -186,7 +186,7 @@ def run_job(
                 ret.return_value = task_function(task_cfg)
                 ret.status = JobStatus.COMPLETED
             except Exception as e:
-                ret.return_value = e
+                ret.return_value = traceback.TracebackException(*sys.exc_info())
                 ret.status = JobStatus.FAILED
 
         ret.task_name = JobRuntime.instance().get("name")
@@ -237,6 +237,14 @@ class JobStatus(Enum):
     COMPLETED = 1
     FAILED = 2
 
+class JobException(Exception):
+    def __init__(self, traceback_exception: traceback.TracebackException) -> None:
+        super().__init__()
+        self.traceback_exception = traceback_exception
+
+    def __str__(self) -> str:
+        body = "".join(self.traceback_exception.format())
+        return f"JobException(\n{body})\n"
 
 @dataclass
 class JobReturn:
@@ -257,7 +265,7 @@ class JobReturn:
             sys.stderr.write(
                 f"Error executing job with overrides: {self.overrides}" + os.linesep
             )
-            raise self._return_value
+            raise JobException(self._return_value)
 
     @return_value.setter
     def return_value(self, value: Any) -> None:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

When Hydra runs jobs (multirun mode), and the job crashes, *only* the exception gets reported and raised (but not the original traceback). This is missing for proper / faster debugging of the original error.
This PR solves that missing feature.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

No

## Test Plan

Tested with the submitit plugin, which pickles the exception information properly.

## Related Issues and PRs
